### PR TITLE
Added FFMPEG options to config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ F10
 ```
 
 - Start xbindkeys with `xbindkeys -f ~/.xbindkeysrc`, or reload it with `killall -s1 xbindkeys` if it's already running, for the new bind to take effect.
-
+- If you would like to enable xbindkeys every time you login, simple add this to your .bash_profile with `echo 'xbindkeys -f $HOME/.xbindkeysrc' >> $HOME/.bash_profile`
   
 
 ### Usage

--- a/README.md
+++ b/README.md
@@ -79,8 +79,7 @@ F10
 ```
 
 - Start xbindkeys with `xbindkeys -f ~/.xbindkeysrc`, or reload it with `killall -s1 xbindkeys` if it's already running, for the new bind to take effect.
-- If you would like to enable xbindkeys every time you login, simple add this to your .bash_profile with `echo 'xbindkeys -f $HOME/.xbindkeysrc' >> $HOME/.bash_profile`
-  
+
 
 ### Usage
 

--- a/example_config
+++ b/example_config
@@ -38,3 +38,22 @@ export REPLAY_BUFFER="5"
 #
 # By default, saves to the default VIDEOS directory
 export VIDEO_FOLDER="$(xdg-user-dir VIDEOS)"
+
+# FFMPEG Command Options
+#
+# Don't mess with these unless you know what you're doing!
+export FFMPEG_COMMAND_VAR='
+    ffmpeg \
+        -f x11grab \
+        -s "$RESOLUTION" \
+        -r ${FPS} \
+        -i "$DISPLAY" \
+        -f pulse -i default \
+        -ar 44100 \
+        $ENCODER_OPTS \
+        -f segment \
+        -segment_time 30 \
+        -segment_wrap "$BUFFER_SEGMENTS" \
+        -segment_list /tmp/ShadowRePlay.m3u8 \
+        -segment_list_size 6 /tmp/ShadowRePlaySeg%d.ts
+'

--- a/example_config
+++ b/example_config
@@ -40,9 +40,9 @@ export REPLAY_BUFFER="5"
 export VIDEO_FOLDER="$(xdg-user-dir VIDEOS)"
 
 # FFMPEG Command Options
-#
+# Change these to change how shadowreplay works with ffmpeg
 # Don't mess with these unless you know what you're doing!
-export FFMPEG_COMMAND_VAR='
+ffmpeg_command(){  # Create the function
     ffmpeg \
         -f x11grab \
         -s "$RESOLUTION" \
@@ -56,4 +56,7 @@ export FFMPEG_COMMAND_VAR='
         -segment_wrap "$BUFFER_SEGMENTS" \
         -segment_list /tmp/ShadowRePlay.m3u8 \
         -segment_list_size 6 /tmp/ShadowRePlaySeg%d.ts
-'
+}
+
+
+export -f ffmpeg_command  # Export the function 

--- a/shadowreplay
+++ b/shadowreplay
@@ -65,10 +65,6 @@ case $ENCODER_API in
         ;;
 esac
 
-ffmpeg_command(){
-    # This is now controlled by the config file for greater accessability to user without having to edit the bin.
-    $FFMPEG_COMMAND_VAR
-    }
 
 ffmpeg_command ||
 

--- a/shadowreplay
+++ b/shadowreplay
@@ -66,19 +66,8 @@ case $ENCODER_API in
 esac
 
 ffmpeg_command(){
-    ffmpeg \
-        -f x11grab \
-        -s "$RESOLUTION" \
-        -r ${FPS} \
-        -i "$DISPLAY" \
-        -f pulse -i default \
-        -ar 44100 \
-        $ENCODER_OPTS \
-        -f segment \
-        -segment_time 30 \
-        -segment_wrap "$BUFFER_SEGMENTS" \
-        -segment_list /tmp/ShadowRePlay.m3u8 \
-        -segment_list_size 6 /tmp/ShadowRePlaySeg%d.ts
+    # This is now controlled by the config file for greater accessability to user without having to edit the bin.
+    $FFMPEG_COMMAND_VAR
     }
 
 ffmpeg_command ||


### PR DESCRIPTION
By doing this, it will allow an easier way for the user to add fixes like [atagen's](https://github.com/atagen), without needing to directly edit the file in /usr/local/bin, as well as allowing for greater customization. 
I'd recommend testing this on some other distro's before merging, as I've only really had the opportunity to test it on my local Arch machine. 

Cheers - Jake